### PR TITLE
fix(cache): correct scope for encapsulation pattern

### DIFF
--- a/lua/kanagawa-paper/lib/cache.lua
+++ b/lua/kanagawa-paper/lib/cache.lua
@@ -1,7 +1,7 @@
 local cache_version = 1.0 -- Bump when the cache format changes to automatically invalidate the cache.
 local util = require("kanagawa-paper.lib.util")
 
-M = {}
+local M = {}
 
 --- Get the cache file path for a given key
 ---@param key string


### PR DESCRIPTION
Theme load failed with the V2 update in my neovim configuration. Found this while investigating. Thanks for a great colorscheme!