### PR TITLE
fix: Unclosed quote in `Customizing colors` section of README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ require('kanagawa-paper').setup({
       ink = {
         ui = {
           float = {
-            fg = "#ff0000,
+            fg = "#ff0000",
           },
         },
       },


### PR DESCRIPTION
Just closes the quote in line `295` of the README
