### PR TITLE
feat(wezterm_tabline)!: use theme instead of overrides

### DIFF
--- a/lua/kanagawa-paper/extras/wezterm_tabline.lua
+++ b/lua/kanagawa-paper/extras/wezterm_tabline.lua
@@ -14,7 +14,7 @@ function M.generate(colors)
 
 local M = {}
 
-M.theme_overrides = {
+M = {
   normal_mode = {
     a = { fg = "${ui.bg_p2}", bg = "${modes.normal}" },
     b = { fg = "${modes.normal}", bg = "${ui.bg_p2}" },
@@ -44,7 +44,27 @@ M.theme_overrides = {
     active = { fg = '${modes.normal}', bg = '${ui.tabline.bg_selected}', bold = true },
     inactive = { fg = '${ui.fg_gray}', bg = '${ui.bg_statusline}' },
     inactive_hover = { fg = '${ui.tabline.fg_alternate}', bg = '${ui.tabline.bg_selected}' },
-  }
+  },
+	ansi = {
+  "${term.black}",
+  "${term.red}",
+  "${term.green}",
+  "${term.yellow}",
+  "${term.blue}",
+  "${term.magenta}",
+  "${term.cyan}",
+  "${term.white}",
+	},
+	brights = {
+  "${term.black_bright}",
+  "${term.red_bright}",
+  "${term.green_bright}",
+  "${term.yellow_bright}",
+  "${term.blue_bright}",
+  "${term.magenta_bright}",
+  "${term.cyan_bright}",
+  "${term.white_bright}",
+	},
 }
 
 return M

--- a/lua/wezterm/theme_switcher.lua
+++ b/lua/wezterm/theme_switcher.lua
@@ -55,9 +55,9 @@ end
 
 function M.apply_tabline_theme(theme)
 	if tabline and theme == "kanagawa-paper-ink" then
-		tabline.set_theme(M.ink.theme_overrides)
+		tabline.set_theme(M.ink)
 	elseif tabline and theme == "kanagawa-paper-canvas" then
-		tabline.set_theme(M.canvas.theme_overrides)
+		tabline.set_theme(M.canvas)
 	end
 end
 


### PR DESCRIPTION
this allows us to set ansi terminal colors as well

